### PR TITLE
Adds a git clone for https

### DIFF
--- a/pages/tutorial/setup/step-4.html
+++ b/pages/tutorial/setup/step-4.html
@@ -27,6 +27,10 @@ To do that, run this command to clone server into your local environment:
 ```sh
 $ git clone git@github.com:lore/lore-tutorial-api.git
 ```
+or
+```sh
+git clone https://github.com/lore/lore-tutorial-api.git
+```
 
 ### Install Dependencies
 Next navigate into the directory and install the dependencies:


### PR DESCRIPTION
Since not everyone uses ssh, adding the command for the clone with https might be helpful. Also you might be cloning on machine that isn't yours so you need https.