### PR TITLE
Adds ES6 code alternative to routing step

### DIFF
--- a/pages/tutorial/routing/step-2.html
+++ b/pages/tutorial/routing/step-2.html
@@ -54,7 +54,14 @@ var Router = require('react-router');
   Lore Tutorial
 </Router.Link>
 ```
-
+Or for ES6 projects you can use ES6 modules.
+```jsx
+import {Link} from 'react-router';
+...
+<Link className="navbar-brand" to="/">
+  Lore Tutorial
+</Link>
+```
 ### Visual Check-in
 
 If everything went well, your application will look exactly the same, but now the title in the header will be a


### PR DESCRIPTION
I decided to do the tutorial in ES6. I found this step confusing since I didn't have import Router at all just Link. I am not sure if you want to add this since there are many steps and all of them will have ES6. But maybe add a disclaimer somewhere telling users to expect ES6 in some places and not others.