### PR TITLE
Correct the creatClass misspellings

### DIFF
--- a/_includes/features/usage/filtering/es5.html
+++ b/_includes/features/usage/filtering/es5.html
@@ -8,7 +8,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired

--- a/_includes/features/usage/pagination/es5.html
+++ b/_includes/features/usage/pagination/es5.html
@@ -11,7 +11,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired

--- a/pages/features/challenges/404-pages.html
+++ b/pages/features/challenges/404-pages.html
@@ -55,7 +55,7 @@ model = {
 This in turn allows you to communicate "not found" experiences much easier to a user:
 
 ```jsx
-React.creatClass({
+React.createClass({
 
   propTypes: {
     post: React.PropTypes.object.isRequired

--- a/pages/features/challenges/error-handling.html
+++ b/pages/features/challenges/error-handling.html
@@ -87,7 +87,7 @@ model = {
 And you can access the error from within your components by looking at the `model.error` field like this:
 
 ```jsx
-React.creatClass({
+React.createClass({
 
   propTypes: {
     post: React.PropTypes.object.isRequired

--- a/pages/features/challenges/filtering.html
+++ b/pages/features/challenges/filtering.html
@@ -169,7 +169,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired

--- a/pages/features/challenges/infinite-scrolling.html
+++ b/pages/features/challenges/infinite-scrolling.html
@@ -44,7 +44,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired
@@ -90,7 +90,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired
@@ -149,7 +149,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired
@@ -212,7 +212,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired
@@ -286,7 +286,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired
@@ -377,7 +377,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired

--- a/pages/features/challenges/pagination.html
+++ b/pages/features/challenges/pagination.html
@@ -202,7 +202,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired
@@ -249,7 +249,7 @@ lore.connect(function(getState, props) {
       })
     };
   })(
-  React.creatClass({
+  React.createClass({
 
     propTypes: {
       posts: React.PropTypes.object.isRequired

--- a/pages/features/challenges/visual-cues.html
+++ b/pages/features/challenges/visual-cues.html
@@ -85,7 +85,7 @@ signify that this resource is not being modified or deleted.
 You can also think of resolved resources as the default rendering state, like this:
 
 ```jsx
-React.creatClass({
+React.createClass({
   displayName: 'Post',
 
   propTypes: {
@@ -130,7 +130,7 @@ to provide a visual indication of this state to the user. If you're rendering a 
 to avoid React warnings you can use the `cid` property.
 
 ```jsx
-React.creatClass({
+React.createClass({
 
   propTypes: {
     posts: React.PropTypes.object.isRequired
@@ -177,7 +177,7 @@ When rendering a resource being updated, it's recommended that you modifying the
 to provide a visual indication of this state to the user.
 
 ```jsx
-React.creatClass({
+React.createClass({
 
   propTypes: {
     posts: React.PropTypes.object.isRequired
@@ -223,7 +223,7 @@ When rendering a resource being deleting, it's recommended that you modifying th
 to provide a visual indication of this state to the user.
 
 ```jsx
-React.creatClass({
+React.createClass({
 
   propTypes: {
     posts: React.PropTypes.object.isRequired
@@ -268,7 +268,7 @@ When rendering a resource being fetched, it's recommended that you modifying the
 to provide a visual indication of this state to the user.
 
 ```jsx
-React.creatClass({
+React.createClass({
 
   propTypes: {
     posts: React.PropTypes.object.isRequired


### PR DESCRIPTION
I noticed that React.creatClass was in several areas of the website, so I've corrected these.