### PR TITLE
Make snippet match with bottom code changes

### DIFF
--- a/pages/quickstart/data/step-1.html
+++ b/pages/quickstart/data/step-1.html
@@ -98,7 +98,7 @@ class Feed extends Component {
 
 ...
 
-Feed.defaultProps = function() {
+Feed.defaultProps = (function() {
   const tweet = {
     id: 1,
     cid: 'c1',
@@ -117,14 +117,14 @@ Feed.defaultProps = function() {
       data: [tweet]
     }
   }
-};
+})();
 ```
 {% endtab %}
 {% tab id=106 %}
 ```jsx
 class Feed extends Component {
 
-  static defaultProps = function() {
+  static defaultProps = (function() {
     const tweet = {
       id: 1,
       cid: 'c1',
@@ -145,7 +145,7 @@ class Feed extends Component {
     }
   }
   ...
-}
+})();
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The upper snippet for the Feed.defaultProps for ES6/ESNextblock is missing
parenthesis, this omission however is not reflected in the Code Changes
section. This change makes it consistent in both locations and will
avoid confusion for a tutorial learner who is typing as they read.