### PR TITLE
fix es6 tab using esnext style decorator

### DIFF
--- a/pages/quickstart/authorization/step-2.html
+++ b/pages/quickstart/authorization/step-2.html
@@ -272,7 +272,6 @@ module.exports = UserCanDeleteTweet(React.createClass({
 import React, { Component, PropTypes } from 'react';
 import UserCanDeleteTweet from '../decorators/UserCanDeleteTweet';
 
-@UserCanDeleteTweet
 class DeleteLink extends Component {
 
   constructor(props) {
@@ -309,7 +308,7 @@ DeleteLink.propTypes = {
   tweet: PropTypes.object.isRequired
 };
 
-export default DeleteLink;
+export default UserCanDeleteTweet(DeleteLink);
 ```
 {% endtab %}
 {% tab id=6 %}


### PR DESCRIPTION
The es6 tab at the bottom "Code Changes" was showing esnext style
decorator invocation. This change makes the es6 code listing
consistent.